### PR TITLE
New Filter: Undefined Street

### DIFF
--- a/WME Wide-Angle Lens Places.user.js
+++ b/WME Wide-Angle Lens Places.user.js
@@ -117,6 +117,8 @@ var WMEWAL_Places;
             "<label for='_wmewalPlacesNoHouseNumber' style='padding-left: 20px'>Missing House Number</label></td></tr>";
         html += "<tr><td><input type='checkbox' id='_wmewalPlacesNoStreet'/>" +
             "<label for='_wmewalPlacesNoStreet' style='padding-left: 20px'>Missing Street</label></td></tr>";
+        html += "<tr><td><input type='checkbox' id='_wmewalPlacesUndefStreet' />" +
+            "<label for='_wmewalPlacesUndefStreet' style='padding-left: 20px' title='Street ID not found in W.model.streets.objects, possibly as a result of a cities form Merge or Delete'>Undefined Street ID</label></td></tr>"
         html += "<tr><td><input type='checkbox' id='_wmewalPlacesAdLocked'/>" +
             "<label for='_wmewalPlacesAdLocked' style='padding-left: 20px'>Ad Locked</label></td></tr>";
         html += "<tr><td ><input type='checkbox' id='_wmewalPlacesUpdateRequests'/>" +
@@ -224,6 +226,7 @@ var WMEWAL_Places;
         $("#_wmewalPlacesType").val(settings.PlaceType);
         $("#_wmewalPlacesEditable").prop("checked", settings.EditableByMe);
         $("#_wmewalPlacesNoHouseNumber").prop("checked", settings.NoHouseNumber);
+        $("#_wmewalPlacesUndefStreet").prop("checked", settings.UndefStreet);
         $("#_wmewalPlacesAdLocked").prop("checked", settings.AdLocked);
         $("#_wmewalPlacesUpdateRequests").prop("checked", settings.UpdateRequests);
         $("#_wmewalPlacesPendingApproval").prop("checked", settings.PendingApproval);
@@ -301,6 +304,7 @@ var WMEWAL_Places;
                 LockLevelOperation: parseInt($("#_wmewalPlacesLockLevelOp").val()),
                 EditableByMe: $("#_wmewalPlacesEditable").prop("checked"),
                 AdLocked: $("#_wmewalPlacesAdLocked").prop("checked"),
+                UndefStreet: $("#_wmewalPlacesUndefStreet").prop("checked"),
                 UpdateRequests: $("#_wmewalPlacesUpdateRequests").prop("checked"),
                 PlaceType: null,
                 PendingApproval: $("#_wmewalPlacesPendingApproval").prop("checked"),
@@ -425,6 +429,7 @@ var WMEWAL_Places;
             settings.NoHouseNumber = $("#_wmewalPlacesNoHouseNumber").prop("checked");
             settings.EditableByMe = $("#_wmewalPlacesEditable").prop("checked");
             settings.AdLocked = $("#_wmewalPlacesAdLocked").prop("checked");
+            settings.UndefStreet = $("#_wmewalPlacesUndefStreet").prop("checked");
             settings.UpdateRequests = $("#_wmewalPlacesUpdateRequests").prop("checked");
             settings.PendingApproval = $("#_wmewalPlacesPendingApproval").prop("checked");
             settings.NoStreet = $("#_wmewalPlacesNoStreet").prop("checked");
@@ -448,6 +453,7 @@ var WMEWAL_Places;
                     (nameRegex == null || nameRegex.test(venue.attributes.name)) &&
                     (!settings.NoHouseNumber || address == null || address.attributes == null || address.attributes.houseNumber == null) &&
                     (!settings.AdLocked || venue.attributes.adLocked) &&
+                    (!settings.UndefStreet || typeof W.model.streets.objects[venue.attributes.streetID] === 'undefined' ) &&
                     (!settings.UpdateRequests || venue.hasOpenUpdateRequests()) &&
                     (!settings.PendingApproval || !venue.isApproved()) &&
                     (!settings.NoStreet || address == null || address.attributes == null || address.attributes.street == null || address.attributes.street.isEmpty || address.attributes.street.name == null)) {
@@ -505,6 +511,8 @@ var WMEWAL_Places;
                         // navigationPoint: venue.getNavigationPoint(),
                         categories: categories,
                         adLocked: venue.attributes.adLocked,
+                        streetID: venue.attributes.streetID,
+                        UndefStreet: (typeof W.model.streets.objects[venue.attributes.streetID] === 'undefined'),
                         hasOpenUpdateRequests: venue.hasOpenUpdateRequests(),
                         placeType: ((venue.isPoint() && !venue.is2D()) ? I18n.t("edit.landmark.type.point") : I18n.t("edit.landmark.type.area")),
                         isApproved: venue.isApproved(),


### PR DESCRIPTION
Filter by  (typeof W.model.streets.objects[venue.attributes.streetID] === 'undefined' )
This commonly happens when the associated cityId is eliminated as a result of a city form Delete or Merge.

(In many cases, the street name can be recovered using `https://${window.location.host}/SearchServer/mozi?lon=${venuePtLatLon.x}&lat=${venuePtLatLon.y}&format=PROTO_JSON_FULL&venue_id=venues.${venue.attributes.id}`; the fix could be built into other scripts)