### PR TITLE
Allow map viewport to have unlimited size in WME

### DIFF
--- a/WME Wide-Angle Lens.user.js
+++ b/WME Wide-Angle Lens.user.js
@@ -198,6 +198,8 @@ var WMEWAL;
     let layerCheckboxAdded = false;
     let WALMap;
     let errList = [];
+    // Make viewport unlimited
+    document.head.appendChild((() => {let style = document.createElement("style");style.innerText = '#editor-container #WazeMap { max-height: none !important; max-width: none !important; height: 100% !important; width: 100% !important}';return style})());
     function onWmeReady() {
         initCount++;
         if (WazeWrap && WazeWrap.Ready) {


### PR DESCRIPTION
This allows WAL to scan more area by allowing the size of the map viewport to be unlimited.

Setting the browser zoom level to 25% covers vastly more area, allowing WAL to run much faster.